### PR TITLE
Added skipdata capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.tmp
 /__pycache__
+testdata.csv

--- a/IWN-ingest.py
+++ b/IWN-ingest.py
@@ -353,6 +353,8 @@ def check_dates(data_file,last_record):
                 continue
             elif last_record[j][0] != 'ok':
                 date_filter.append(True)
+            elif args.skipdata:
+                date_filter.append(True)
             else:
                 date = row[1]
                 time = row[2]
@@ -556,15 +558,18 @@ def push_new_templates(data,last_record,date_filter,stationmeta,parameta):
 
 if __name__ == "__main__":
     #Parse arguments
-    parser = argparse.ArgumentParser()
-    parser.add_argument("d", help="data file relative location")
-    parser.add_argument("c", help="config file relative location")
+    parser = argparse.ArgumentParser(description="Interoperable Watershed Network 52 North SOS Ingester")
+    parser.add_argument("d", metavar="[data file]", help="data file relative location")
+    parser.add_argument("c", metavar="[config file]", help="config file relative location")
+    parser.add_argument("-s","--skipdata", help="bypass server date check and push all data",action="store_true")
     args = parser.parse_args()
-
 
     log_entry("*","*************")
     log_entry("*","Start Program")
     log_entry("*","*************")
+    if args.skipdata:
+        print("* Skipping data check. Pushing all data to server regardless of date.")
+        log_entry("*","SKIPPING DATA CHECK. PUSHING ALL DATA TO SERVER REGARDLESS OF DATE")
     filelist = glob("temp/PART_*.csv")
     for nfile in filelist:
         os.remove(nfile)

--- a/testdata.csv
+++ b/testdata.csv
@@ -1,7 +1,0 @@
-Station,Huc14,Latitude,Longitude,System_ID,county,municipality,Date_Time,Temperature C,Specific_Conductance mS/cm,Salinity ppt,DO %,DO Concentration mg/l,DO Charge,pH,Turbidity NTU,Chlorophyll ug/l
-BB04a,2.0403E+12,39.93289,-74.14069,4,OCEAN,Berkeley Township,6/10/2015 10:16,22.55,29.69,18.39,98.2,7.64,,7.85,0.7,11.3
-BB04a,2.0403E+12,39.93289,-74.14069,4,OCEAN,Berkeley Township,6/10/2015 10:31,22.58,29.4,18.2,98.8,7.69,,7.86,0.8,11.8
-BB04a,2.0403E+12,39.93289,-74.14069,4,OCEAN,Berkeley Township,6/10/2015 10:46,22.6,29.81,18.48,99.6,7.74,,7.87,0.8,11
-BB04a,2.0403E+12,39.93289,-74.14069,4,OCEAN,Berkeley Township,6/10/2015 11:01,22.7,29.12,18.01,101,7.85,,7.89,0.8,11.9
-BB04a,2.0403E+12,39.93289,-74.14069,4,OCEAN,Berkeley Township,6/10/2015 11:16,22.72,29.27,18.11,102.2,7.94,,7.89,0.8,11.2
-BB04a,2.0403E+12,39.93289,-74.14069,4,OCEAN,Berkeley Township,6/10/2015 11:31,22.71,29.91,18.54,102.6,7.96,,7.9,0.9,13.7


### PR DESCRIPTION
added usage flag "-s" or "--skipdata" that can be placed anywhere in the command. Invokes "Skip data mode." When used, all data will be pushed to the server regardless of the date, and even data that potentially has already been pushed to the server will be pushed. Used to fill in gaps in data. Should be used carefully. No warning before pushing data.

In practice, the server rejects duplicate data, so there is some safety built into the option.